### PR TITLE
Optimize raw data requests.

### DIFF
--- a/xdmod_data/_http_requester.py
+++ b/xdmod_data/_http_requester.py
@@ -67,11 +67,19 @@ class _HttpRequester:
                 partial_data = response['data']
                 data += partial_data
                 if params['show_progress']:
-                    progress_msg = 'Got ' + str(len(data)) + ' rows...'
-                    print(progress_msg, end='\r')
+                    progress_msg = self.__show_progress(
+                        start_date,
+                        current_date,
+                        len(data),
+                    )
                 num_rows = len(partial_data)
                 offset += limit
             current_date = current_date + timedelta(days=1)
+            progress_msg = self.__show_progress(
+                start_date,
+                current_date,
+                len(data),
+            )
         if params['show_progress']:
             print(progress_msg + 'DONE')
         return (data, response['fields'])
@@ -157,3 +165,15 @@ class _HttpRequester:
             response = self._request_json('/rest/v1/warehouse/raw-data/limit')
             self.__raw_data_limit = int(response['data'])
         return self.__raw_data_limit
+
+    def __show_progress(self, start_date, current_date, num_rows):
+        num_days = (current_date - start_date).days
+        progress_msg = (
+            'Got ' + str(num_rows) + ' row'
+            + ('s' if num_rows != 1 else '')
+            + ' (' + str(num_days) + ' day'
+            + ('s' if num_days != 1 else '')
+            + ')...'
+        )
+        print(progress_msg, end='\r')
+        return progress_msg

--- a/xdmod_data/warehouse.py
+++ b/xdmod_data/warehouse.py
@@ -168,8 +168,8 @@ class DataWarehouse:
                only be included whose values for each of the given dimensions
                match one of the corresponding given values.
            show_progress : bool, optional
-               If true, periodically print how many rows have been gotten so
-               far.
+               If true, periodically print how many rows and how many days in
+               the date range have been gotten so far.
 
            Returns
            -------


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This improves the performance of raw data requests.

Instead of repeatedly requesting the entire time range in chunks of 10,000 rows (or whatever the portal has configured as the `rest_raw_row_limit`), the method now makes a separate request for each day in the range, still in chunks of 10,000 rows (or whatever`rest_raw_row_limit` is).

For example, instead of:
```
start_date=2023-01-01&end_date=2023-01-31&offset=0
start_date=2023-01-01&end_date=2023-01-31&offset=10000
start_date=2023-01-01&end_date=2023-01-31&offset=20000
...
```

it is now (note that for each request, `start_date == end_date`):
```
start_date=2023-01-01&end_date=2023-01-01&offset=0
start_date=2023-01-01&end_date=2023-01-01&offset=10000
start_date=2023-01-01&end_date=2023-01-01&offset=20000
...
start_date=2023-01-02&end_date=2023-01-02&offset=0
start_date=2023-01-02&end_date=2023-01-02&offset=10000
start_date=2023-01-02&end_date=2023-01-02&offset=20000
...
```

The full result is received faster, even though more queries are made (e.g., ~1min for 7 days (258,836 rows) of SUPREMM data as opposed to ~1m20s seconds), and for a portal that implements https://github.com/ubccr/xdmod/pull/1780, requests for raw Jobs realm data are received much faster (around 20 seconds to fetch two days (63,251 rows) of Jobs data as opposed to around 25 minutes).

This also updates the `show_progress` feature to also print the number of days that have been retrieved so far.

TODO: add tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requests for raw data in the ACCESS XDMoD Jobs realm are incredibly slow. This is also the case for `metrics-staging`.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The pull request description is suitable for a Changelog entry
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [ ] Running the automated tests (see `docs/developing.md`) produces no errors.