### PR TITLE
Remove limit on number of results returned from `get_filter_values()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Main development branch
 - Update tests and testing instructions ([\#14](https://github.com/ubccr/xdmod-data/pull/14)).
+- Remove limit on number of results returned from `get_filter_values()` ([\#21](https://github.com/ubccr/xdmod-data/pull/21)).
 
 ## v1.0.0 (2023-07-21)
 - Initial release.

--- a/tests/regression/test_datawarehouse_regression.py
+++ b/tests/regression/test_datawarehouse_regression.py
@@ -97,3 +97,15 @@ def test_get_filter_values(valid_dw):
         'jobs-fieldofscience-filter-values.csv',
         valid_dw.get_filter_values('Jobs', 'Field of Science'),
     )
+
+
+def test_get_data_filter_user(valid_dw):
+    # Make sure the filter validation works for a user whose list position is
+    # greater than 10000 — this will raise an exception if it doesn't work.
+    valid_dw.get_data(
+        duration=('2023-01-01', '2023-01-01'),
+        realm='Jobs',
+        metric='CPU Hours: Total',
+        dataset_type='aggregate',
+        filters={'User': '10332'},
+    )

--- a/xdmod_data/_http_requester.py
+++ b/xdmod_data/_http_requester.py
@@ -62,6 +62,27 @@ class _HttpRequester:
             print(progress_msg + 'DONE')
         return (data, response['fields'])
 
+    def _request_filter_values(self, realm_id, dimension_id):
+        limit = 10000
+        data = []
+        num_rows = limit
+        offset = 0
+        while num_rows == limit:
+            response = self._request_json(
+                path='/controllers/metric_explorer.php',
+                post_fields={
+                    'operation': 'get_dimension',
+                    'realm': realm_id,
+                    'dimension_id': dimension_id,
+                    'start': offset,
+                    'limit': limit,
+                },
+            )
+            data += response['data']
+            num_rows = len(response['data'])
+            offset += limit
+        return data
+
     def _request_json(self, path, post_fields=None):
         response = self.__request(path, post_fields)
         return json.loads(response)

--- a/xdmod_data/warehouse.py
+++ b/xdmod_data/warehouse.py
@@ -315,15 +315,11 @@ class DataWarehouse:
             realm_id,
             dimension,
         )
-        path = '/controllers/metric_explorer.php'
-        post_fields = {
-            'operation': 'get_dimension',
-            'dimension_id': dimension_id,
-            'realm': realm_id,
-            'limit': 10000,
-        }
-        response = self.__http_requester._request_json(path, post_fields)
-        data = [(datum['id'], datum['name']) for datum in response['data']]
+        response_data = self.__http_requester._request_filter_values(
+            realm_id,
+            dimension_id,
+        )
+        data = [(datum['id'], datum['name']) for datum in response_data]
         result = self.__get_data_frame(data, ('id', 'label'), 'id')
         return result
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR removes the limit on the number of results returned from the `get_filter_values()` method. The limit was arbitrary and unnecessary.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR adds a new regression test to make sure more than 10,000 (the previous limit) results are returned.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `CHANGELOG.md` has been updated
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [x] Running the automated tests (see `docs/developing.md`) produces no errors
- [x] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully