### PR TITLE
Rename `dimension` parameter to `group_by`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Main development branch
 
 - Document Open XDMoD compatibility in changelog ([\#31](https://github.com/ubccr/xdmod-data/pull/31)).
+- Rename `dimension` parameter to `group_by` ([\#33](https://github.com/ubccr/xdmod-data/pull/33)).
 
 ## v1.0.1 (2024-09-27)
 


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR renames the `dimension` parameter of the `get_data()` method to `group_by`.

The `dimension` parameter will still work but is given a deprecation warning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The goal is to have a parameter name that is more accurate and clear. Dimensions can be used for both grouping and filtering. In this case, the dimension is used for grouping.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring / documentation update (non-breaking change which does not change functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release preparation

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `CHANGELOG.md` has been updated
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [ ] Running the automated tests (see `docs/developing.md`) produces no errors
- [ ] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully
