### PR TITLE
Add stub CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+jobs:
+  build:
+    parameters:
+      python-version:
+        type: string
+    docker:
+      - image: cimg/python:#{python-version}
+    steps:
+      - checkout
+      - run:
+          name: Lint with Flake8
+          command: |
+            flake8 . --max-complexity=10 --show-source --exclude __init__.py
+workflows:
+  full-build:
+    jobs:
+      - build:
+          matrix:
+            parameters:
+              python-version:
+                - "3.13"
+                - "3.12"
+                - "3.11"
+                - "3.10"
+                - "3.9"
+                - "3.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prepare for v2.0.0 development ([\#42](https://github.com/ubccr/xdmod-data/pull/42)).
 - Implement 100% test coverage ([\#27](https://github.com/ubccr/xdmod-data/pull/27)).
 - Update Flake8 rules ([\#28](https://github.com/ubccr/xdmod-data/pull/28)).
+- Add stub CircleCI config ([\#48](https://github.com/ubccr/xdmod-data/pull/48)).
 
 ## v1.0.2 (2024-10-31)
 

--- a/xdmod_data/__version__.py
+++ b/xdmod_data/__version__.py
@@ -1,2 +1,2 @@
 __title__ = 'xdmod-data'
-__version__ = '2.0.0-03'
+__version__ = '2.0.0-04'


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR adds a stub configuration file for CircleCI. It will be filled out in a subsequent PR after setting it up in the CircleCI dashboard.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looking to move from GitHub Actions to CircleCI for testing since we have higher usage limits there and to use the same tool as the other repos for easier management.

## Type of change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring / documentation update (non-breaking change which does not change functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release preparation

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `CHANGELOG.md` has been updated
- [x] `xdmod_data/__version__.py` has been updated to the next development version
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [x] Running the automated tests (see `docs/developing.md`) produces no errors
- [x] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully
- [ ] The changes in this PR have been ported/backported to other branches as needed
