### PR TITLE
Remove unnecessary request made when runtime context is entered.

### DIFF
--- a/tests/unit/test_datawarehouse_unit.py
+++ b/tests/unit/test_datawarehouse_unit.py
@@ -46,7 +46,7 @@ def test___enter___RuntimeError_xdmod_host_malformed():
             r'(Invalid URL \'.*\': No host supplied|'
             + r'Invalid URL \'https:/controllers/metric_explorer.php\':'
             + r'No schema supplied. Perhaps you meant'
-            + r'http://https:/controllers/metric_explorer.php\?'
+            + r'http://https:/controllers/metric_explorer.php\?)'
         ),
     ):
         with DataWarehouse('https://') as dw:

--- a/tests/unit/test_datawarehouse_unit.py
+++ b/tests/unit/test_datawarehouse_unit.py
@@ -49,15 +49,15 @@ def test___enter___RuntimeError_xdmod_host_malformed():
             + INVALID_STR + r'\?)'
         ),
     ):
-        with DataWarehouse('https://'):  # pragma: no cover
-            pass
+        with DataWarehouse('https://') as dw:
+            dw.describe_realms()
 
 
 def test___enter___RuntimeError_xdmod_host_unresolved():
     invalid_host = 'https://' + INVALID_STR + '.xdmod.org'
     with pytest.raises(Exception):
-        with DataWarehouse(invalid_host):  # pragma: no cover
-            pass
+        with DataWarehouse(invalid_host) as dw:
+            dw.describe_realms()
 
 
 def test___enter___RuntimeError_xdmod_host_unsupported_protocol():
@@ -66,8 +66,8 @@ def test___enter___RuntimeError_xdmod_host_unsupported_protocol():
         requests.exceptions.InvalidSchema,
         match="No connection adapters were found for '" + invalid_host,
     ):
-        with DataWarehouse(invalid_host):  # pragma no cover
-            pass
+        with DataWarehouse(invalid_host) as dw:
+            dw.describe_realms()
 
 
 def test___enter___RuntimeError_401():

--- a/tests/unit/test_datawarehouse_unit.py
+++ b/tests/unit/test_datawarehouse_unit.py
@@ -45,8 +45,8 @@ def test___enter___RuntimeError_xdmod_host_malformed():
         match=(
             r'(Invalid URL \'.*\': No host supplied|'
             + r'Invalid URL \'https:/controllers/metric_explorer.php\':'
-            + r'No schema supplied. Perhaps you meant'
-            + r'http://https:/controllers/metric_explorer.php\?)'
+            + r' No schema supplied. Perhaps you meant'
+            + r' http://https:/controllers/metric_explorer.php\?)'
         ),
     ):
         with DataWarehouse('https://') as dw:

--- a/tests/unit/test_datawarehouse_unit.py
+++ b/tests/unit/test_datawarehouse_unit.py
@@ -44,9 +44,9 @@ def test___enter___RuntimeError_xdmod_host_malformed():
         ),
         match=(
             r'(Invalid URL \'.*\': No host supplied|'
-            + r'Invalid URL \'https:\?Bearer=' + INVALID_STR + "': "
-            + r'No schema supplied. Perhaps you meant http://https:\?Bearer='
-            + INVALID_STR + r'\?)'
+            + r'Invalid URL \'https:/controllers/metric_explorer.php\':'
+            + r'No schema supplied. Perhaps you meant'
+            + r'http://https:/controllers/metric_explorer.php\?'
         ),
     ):
         with DataWarehouse('https://') as dw:

--- a/xdmod_data/_http_requester.py
+++ b/xdmod_data/_http_requester.py
@@ -29,7 +29,6 @@ class _HttpRequester:
     def _start_up(self):
         self.__in_runtime_context = True
         self.__requests_session = requests.Session()
-        self.__assert_connection_to_xdmod_host()
 
     def _tear_down(self):
         if self.__requests_session is not None:
@@ -111,15 +110,6 @@ class _HttpRequester:
     def _request_json(self, path, post_fields=None):
         response = self.__request(path, post_fields)
         return json.loads(response)
-
-    def __assert_connection_to_xdmod_host(self):
-        try:
-            self.__request()
-        except RuntimeError as e:  # pragma: no cover
-            raise RuntimeError(
-                "Could not connect to xdmod_host '" + self.__xdmod_host
-                + "': " + str(e),
-            ) from None
 
     def __request(self, path='', post_fields=None, stream=False):
         _validator._assert_runtime_context(self.__in_runtime_context)

--- a/xdmod_data/warehouse.py
+++ b/xdmod_data/warehouse.py
@@ -7,7 +7,7 @@ import xdmod_data._validator as _validator
 
 
 class DataWarehouse:
-    """Access the XDMoD data warehouse via XDMoD's network API.
+    """Request data from an XDMoD data warehouse via the XDMoD REST API.
 
        Methods must be called within a runtime context using the ``with``
        keyword, e.g.,
@@ -24,9 +24,6 @@ class DataWarehouse:
        ------
        KeyError
            If the `XDMOD_API_TOKEN` environment variable has not been set.
-       RuntimeError
-           If a connection cannot be made to the XDMoD server specified by
-           `xdmod_host`.
        TypeError
            If `xdmod_host` is not a string.
     """


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This PR removes the unnecessary request that is made when the runtime context of the `DataWarehouse` is entered. The purpose of having it was to assert that a connection could be made to the XDMoD REST API; however, this will almost always occur just before another request is made, so there is no need to test the initial request.

## Type of change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring / documentation update (non-breaking change which does not change functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release preparation

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `xdmod_data/__version__.py` has been updated to the next development version
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [x] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully