### PR TITLE
Fix Plotly template ValueError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v1.x.y (development branch)
 
-- Prepare for v1.1.0 development ([\#44](https://github.com/ubccr/xdmod-data/pull/44)).
+This release fixes a `ValueError` error that occurs with the Plotly
+`timeseries` template.
+
 - Implement 100% test coverage ([\#45](https://github.com/ubccr/xdmod-data/pull/45)).
 - Update Flake8 rules ([\#46](https://github.com/ubccr/xdmod-data/pull/46)).
 - Change to using CircleCI instead of GitHub Actions for continuous integration
@@ -10,6 +12,7 @@
   [\#53](https://github.com/ubccr/xdmod-data/pull/53),
   [\#56](https://github.com/ubccr/xdmod-data/pull/56),
   [\#58](https://github.com/ubccr/xdmod-data/pull/58)).
+- Fix Plotly template ValueError ([\#](https://github.com/ubccr/xdmod-data/pull/)).
 
 ## v1.0.2 (2024-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release fixes a `ValueError` error that occurs with the Plotly
   [\#53](https://github.com/ubccr/xdmod-data/pull/53),
   [\#56](https://github.com/ubccr/xdmod-data/pull/56),
   [\#58](https://github.com/ubccr/xdmod-data/pull/58)).
-- Fix Plotly template ValueError ([\#](https://github.com/ubccr/xdmod-data/pull/)).
+- Fix Plotly template ValueError ([\#60](https://github.com/ubccr/xdmod-data/pull/60)).
 
 ## v1.0.2 (2024-10-31)
 

--- a/xdmod_data/__version__.py
+++ b/xdmod_data/__version__.py
@@ -1,2 +1,2 @@
 __title__ = 'xdmod-data'
-__version__ = '1.1.0-07'
+__version__ = '1.0.3.dev1'

--- a/xdmod_data/themes.py
+++ b/xdmod_data/themes.py
@@ -73,10 +73,12 @@ pio.templates['timeseries'] = go.layout.Template(
             '#111111',
         ],
         'xaxis': {
-            'titlefont': {
-                'family': 'Arial, sans-serif',
-                'size': 12,
-                'color': '#5078a0',
+            'title': {
+                'font': {
+                    'family': 'Arial, sans-serif',
+                    'size': 12,
+                    'color': '#5078a0',
+                },
             },
             'color': '#606060',
             'ticks': 'outside',
@@ -91,10 +93,12 @@ pio.templates['timeseries'] = go.layout.Template(
             'tickformat': '%Y-%m-%d',
         },
         'yaxis': {
-            'titlefont': {
-                'family': 'Arial, sans-serif',
-                'size': 12,
-                'color': '#1199FF',
+            'title': {
+                'font': {
+                    'family': 'Arial, sans-serif',
+                    'size': 12,
+                    'color': '#1199FF',
+                },
             },
             'color': '#606060',
             'gridcolor': '#bfc0c0',


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->
This release fixes a `ValueError` that occurs with the Plotly `timeseries` template. Plotly recent released version 6.0.0 which removes the deprecated value `titlefont`. The bug can be reproduced by running the example notebooks from `xdmod-notebooks`.

## Type of change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring / documentation update (non-breaking change which does not change functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release preparation

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `CHANGELOG.md` has been updated
- [x] `xdmod_data/__version__.py` has been updated to the next development version
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [x] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully
- [ ] The changes in this PR have been ported/backported to other branches as needed