### PR TITLE
Update documentation.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,9 +26,7 @@
 ## Checklist:
 <!--- Go over all the following points and make sure they have all been completed -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] `CHANGELOG.md` has been updated
 - [ ] `xdmod_data/__version__.py` has been updated to the next development version
 - [ ] The milestone is set correctly on the pull request
 - [ ] The appropriate labels have been added to the pull request
 - [ ] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully
-- [ ] The changes in this PR have been ported/backported to other branches as needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # xdmod-data Changelog
 
-## v2.x.y (main development branch)
-
-## v1.x.y (development branch)
-
 ## v1.0.3 (2025-01-30)
 
 This release fixes a `ValueError` that occurs with the Plotly `timeseries`
@@ -11,7 +7,8 @@ template.
 
 It is compatible with Open XDMoD versions 11.0.x and 10.5.x.
 
-- Implement 100% test coverage ([\#27](https://github.com/ubccr/xdmod-data/pull/27)).
+- Implement 100% test coverage
+  ([\#27](https://github.com/ubccr/xdmod-data/pull/27)).
 - Update Flake8 rules ([\#28](https://github.com/ubccr/xdmod-data/pull/28)).
 - Change to using CircleCI instead of GitHub Actions for continuous integration
   ([\#48](https://github.com/ubccr/xdmod-data/pull/48),
@@ -19,7 +16,8 @@ It is compatible with Open XDMoD versions 11.0.x and 10.5.x.
   [\#51](https://github.com/ubccr/xdmod-data/pull/51),
   [\#52](https://github.com/ubccr/xdmod-data/pull/52),
   [\#59](https://github.com/ubccr/xdmod-data/pull/59)).
-- Fix Plotly template ValueError ([\#61](https://github.com/ubccr/xdmod-data/pull/61)).
+- Fix Plotly template ValueError
+  ([\#61](https://github.com/ubccr/xdmod-data/pull/61)).
 
 ## v1.0.2 (2024-10-31)
 
@@ -28,27 +26,41 @@ This release fixes an `IOPub` error that can occur when calling
 
 It is compatible with Open XDMoD versions 11.0.x and 10.5.x.
 
-- Document Open XDMoD compatibility in changelog ([\#31](https://github.com/ubccr/xdmod-data/pull/31)).
-- Fix IOPub error when showing progress with `get_raw_data()` ([\#39](https://github.com/ubccr/xdmod-data/pull/39)).
+- Document Open XDMoD compatibility in changelog
+  ([\#31](https://github.com/ubccr/xdmod-data/pull/31)).
+- Fix IOPub error when showing progress with `get_raw_data()`
+  ([\#39](https://github.com/ubccr/xdmod-data/pull/39)).
 
 ## v1.0.1 (2024-09-27)
 
-This release has bug fixes, performance improvements, and updates for compatibility, tests, and documentation.
+This release has bug fixes, performance improvements, and updates for
+compatibility, tests, and documentation.
 
 It is compatible with Open XDMoD versions 11.0.x and 10.5.x.
 
-- Add borders to README images ([\#12](https://github.com/ubccr/xdmod-data/pull/12)).
-- Create `PULL_REQUEST_TEMPLATE.md` ([\#13](https://github.com/ubccr/xdmod-data/pull/13)).
-- Add types of changes to pull request template ([\#15](https://github.com/ubccr/xdmod-data/pull/15)).
+- Add borders to README images
+  ([\#12](https://github.com/ubccr/xdmod-data/pull/12)).
+- Create `PULL_REQUEST_TEMPLATE.md`
+  ([\#13](https://github.com/ubccr/xdmod-data/pull/13)).
+- Add types of changes to pull request template
+  ([\#15](https://github.com/ubccr/xdmod-data/pull/15)).
 - Add Changelog ([\#17](https://github.com/ubccr/xdmod-data/pull/17)).
-- Update tests and testing instructions ([\#14](https://github.com/ubccr/xdmod-data/pull/14)).
-- Remove limit on number of results returned from `get_filter_values()` ([\#21](https://github.com/ubccr/xdmod-data/pull/21)).
-- Add citation for the DAF paper ([\#23](https://github.com/ubccr/xdmod-data/pull/23)).
-- Add a "Feedback / Feature Requests" section to the README ([\#22](https://github.com/ubccr/xdmod-data/pull/22)).
-- Improve performance of validation of filters and raw fields ([\#18](https://github.com/ubccr/xdmod-data/pull/18)).
-- Fix bug with trailing slashes in `xdmod_host` ([\#24](https://github.com/ubccr/xdmod-data/pull/24)).
-- Use streaming for raw data requests ([\#19](https://github.com/ubccr/xdmod-data/pull/19)).
-- Specify minimum version numbers for dependencies ([\#25](https://github.com/ubccr/xdmod-data/pull/25)).
+- Update tests and testing instructions
+  ([\#14](https://github.com/ubccr/xdmod-data/pull/14)).
+- Remove limit on number of results returned from `get_filter_values()`
+  ([\#21](https://github.com/ubccr/xdmod-data/pull/21)).
+- Add citation for the DAF paper
+  ([\#23](https://github.com/ubccr/xdmod-data/pull/23)).
+- Add a "Feedback / Feature Requests" section to the README
+  ([\#22](https://github.com/ubccr/xdmod-data/pull/22)).
+- Improve performance of validation of filters and raw fields
+  ([\#18](https://github.com/ubccr/xdmod-data/pull/18)).
+- Fix bug with trailing slashes in `xdmod_host`
+  ([\#24](https://github.com/ubccr/xdmod-data/pull/24)).
+- Use streaming for raw data requests
+  ([\#19](https://github.com/ubccr/xdmod-data/pull/19)).
+- Specify minimum version numbers for dependencies
+  ([\#25](https://github.com/ubccr/xdmod-data/pull/25)).
 
 ## v1.0.0 (2023-07-21)
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Open XDMoD.
 This documentation is for **v2.x.y (main development branch)**. For
 documentation of other versions:
 
-- [v1.0.3](https://github.com/ubccr/xdmod-data/tree/v1.0.3?tab=readme-ov-file#xdmod-data)
-- [v1.0.2](https://github.com/ubccr/xdmod-data/tree/v1.0.2?tab=readme-ov-file#xdmod-data)
-- [v1.0.1](https://github.com/ubccr/xdmod-data/tree/v1.0.1?tab=readme-ov-file#xdmod-data)
-- [v1.0.0](https://github.com/ubccr/xdmod-data/tree/v1.0.0?tab=readme-ov-file#xdmod-data)
-- [v1.x.y (development branch)](https://github.com/ubccr/xdmod-data/tree/v1.x.y?tab=readme-ov-file#xdmod-data)
+- [v1.x.y](https://github.com/ubccr/xdmod-data/tree/v1.x.y?tab=readme-ov-file#xdmod-data)
 
 The package can be installed from PyPI via `pip install xdmod-data`.
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -5,34 +5,39 @@
 A testing script is available in `tests/ci/bootstrap.sh`. It requires Docker
 Compose and `yq`.
 
+To test with the notebooks in `xdmod-notebooks`, you can edit their first code
+cell to replace `xdmod-data` and its version constraints with the following,
+replacing `username` with your username and `branch-name` with the name of the
+branch:
+```
+git+https://github.com/username/xdmod-data.git@branch-name
+```
+
+## Contributing a Pull Request (PR)
+
+1. Get the PR reviewed.
+1. Once the PR is approved and merged,
+    1. In the release prep draft PR for the version under development:
+        1. In `CHANGELOG.md`:
+            1. Add the PR you just merged.
+            1. If needed, update the summary of the version under development
+               and its compatibility with Open XDMoD versions.
+        1. In `README.md`:
+            1. If needed, update the Open XDMoD compatibility matrix.
+    1. If needed, port/backport the PR to other development branches, and
+       update their release prep draft PRs as well.
+
 ## Releasing a new version
 
-1. Make a new branch of `xdmod-data` and:
-    1. Make sure the version number is updated in `xdmod_data/__version__.py`.
-    1. In `README.md`:
-        1. Under the main heading,
-            1. In the sentence that begins, `This documentation is for ...`,
-               replace the version number in bold, e.g.:
-                ```
-                This documentation is for **v1.0.2**.
-                ```
-            1. Add the following item to the list, replacing `1` with the major
-               version number of the new release. The development branches
-               should be listed in order of major version, ascending (`1.x.y`,
-               `2.x.y`, etc.):
-                ```
-                - [v1.x.y (development branch)](https://github.com/ubccr/xdmod-data/tree/v1.x.y?tab=readme-ov-file#xdmod-data)
-                ```
-        1. Update the Open XDMoD compatibility matrix.
-    1. Update `CHANGELOG.md` to:
-        1. Change the `development branch` to, e.g., `v1.0.1 (2024-06-XX)`.
-        1. Add a summary of the changes in the version, including the
-           compatibilty with Open XDMoD versions.
-    1. In `setup.cfg`, update the `long_description` to change the version
-       number in the URL to the new version.
-    1. Create a Pull Request for the new version.
-1. After the Pull Request is approved (but not merged yet), follow these steps
-   in a cloned copy of the branch:
+1. In the version's release prep draft PR:
+    1. In `xdmod_data/__version__.py`, make sure the version number is updated.
+    1. In `README.md`, make sure the Open XDMoD compatibility matrix is
+       updated.
+    1. In `CHANGELOG.md`, update the release date of the version and make sure
+       it has a summary of the changes in the version and indicates the
+       compatibility with Open XDMoD versions.
+1. After the PR is approved (but not merged yet), follow these steps in a
+   cloned copy of the branch:
     1. Start up a virtual environment, e.g.:
         ```
         python3 -m venv ~/xdmod-data-build-env
@@ -47,9 +52,9 @@ Compose and `yq`.
         ```
         python3 -m build --wheel
         ```
-    1. Validate `setup.cfg`, e.g., for version 1.0.0-beta1:
+    1. Validate `setup.cfg`, e.g., for version 1.0.1:
         ```
-        version=1.0.0b1
+        version=1.0.1
         twine check dist/xdmod_data-${version}-py3-none-any.whl
         ```
         Make sure you receive `PASSED`.
@@ -67,10 +72,9 @@ Compose and `yq`.
         Enter your PyPI username and password.
     1. Go to https://pypi.org/project/xdmod-data and confirm the new version is
        the latest release.
-1. Update the date of the release in `CHANGELOG.md` and commit it to the Pull
-   Request.
-1. Merge the Pull Request.
-1. Go to [create a new release on GitHub](https://github.com/ubccr/xdmod-data/releases/new) and:
+1. Merge the PR.
+1. Go to [create a new release on
+   GitHub](https://github.com/ubccr/xdmod-data/releases/new) and:
     1. Click `Choose a tag`.
     1. Type in a tag similar to `v1.0.0` and choose `Create new tag`.
     1. Choose the correct target based on the major version you are developing.
@@ -83,46 +87,59 @@ Compose and `yq`.
     1. Where it says `Attach binaries`, attach the built distribution (the
        `.whl` file) that was uploaded to PyPI.
     1. Click `Publish release`.
-    1. Go to the [GitHub milestones](https://github.com/ubccr/xdmod-data/milestones)
-       and close the milestone for the version.
+    1. Go to the [GitHub
+       milestones](https://github.com/ubccr/xdmod-data/milestones) and close
+       the milestone for the version.
 
 ## After release
 
-1. If you just released a new major version,
-    1. Create a branch off `main` for the previous major version called, e.g.,
-       `v1.x.y`.
-1. If this is a minor or patch release to a version that is not the most recent
-   major version,
-    1. For each major version above this release's major version, in a Pull
-       Request,
-        1. Add the entry for this version to the `CHANGELOG.md`. Note that the
-           PR numbers should match the ones that were merged into the major
-           branch whose Pull Request you are currently creating, NOT the branch
-           that the release was tagged on.
-        1. In the `README.md`:
-            1. Add an item to the top of the bulleted list for
-               the new version, making sure to replace the version number in
-               the link text and in the URL.
-            1. Update the Open XDMoD compatibility matrix.
-        1. Get the Pull Request approved and merged.
-1. In a Pull Request to the same branch you just released:
-    1. Make sure the version number is updated in `xdmod_data/__version__.py`
-       to a development pre-release of the next version, e.g., `1.0.1.dev01`.
+1. If you just released a new major version (e.g., `2.0.0`),
+    1. Create a branch off `main` for that major version (e.g., `v2.x.y`).
+    1. For each major version below that major version (e.g., `1.x.y`), make a
+       PR to that branch that updates `README.md` to add a link to the new
+       version's README to the list under `For documentation of other
+       versions:` and updates the main development branch's link text in that
+       list to the next major version (e.g., `v3.x.y (main development
+       branch)`). Get the PR approved and merged.
+    1. In a PR to the `main` branch, update the `README.md` under the main
+       heading, in the sentence that begins `This documentation is for ...`,
+       update the version number in the bold text (e.g., `**v3.x.y (main
+       development branch)**`. Get the PR approved and merged.
+1. If you just released a new minor or patch version of a version that is not
+   the most recent major version under development (e.g., `v1.1.0`):
+    1. For each major version above that version's major version (e.g.,
+      `v2.x.y`), in that major version's release prep draft PR:
+        1. In `CHANGELOG.md`, make sure the version just released is present
+           but that the PR numbers match the ones that were merged into the
+           major branch whose Pull Request you are currently creating, NOT the
+           branch that the release was tagged on.
+        1. In the `README.md`, update the Open XDMoD compatibility matrix.
+        1. Get the PR approved and merged.
+1. In a PR to the same branch you just released:
+    1. In `xdmod_data/__version__.py`, make sure the version number is updated
+       to a development pre-release of the next version, e.g., `3.0.0.dev01`.
     1. In `README.md`:
-        1. Under the main heading, in the sentence that begins, `This
-           documentation is for ...`, replace the version number in bold, e.g.:
-            ```
-            This documentation is for **v1.x.y (development branch)**.
-            ```
-        1. Add an item to the top of the bulleted list for
-           the new version, making sure to replace the version number in
-           the link text and in the URL.
-        1. Remove the item from the bulleted list for the `v1.x.y (development
-           branch)` (where `1` is the major version number).
-    1. Update `CHANGELOG.md` to add a section at the top called
-       `v1.x.y (development branch)`, replacing `1` with the major version under
-       development (if it is also the main development branch, change
-       `development branch` to `main development branch`).
-    1. Get the Pull Request approved and merged.
-1. Go to the [GitHub milestones](https://github.com/ubccr/xdmod-data/milestones)
-   and add a milestone for the version under development.
+        1. If you just released a new major version:
+            1. Under the main heading, in the sentence that begins `This
+               documentation is for ...`, update the bold text from e.g.,
+               `**v2.x.y (main development branch)**` to, e.g., `the **v2.x.y**
+               versions`.
+            1. In the list under `For documentation of other versions:`, update
+               the main development branch's link text to the next major
+               version (e.g., `v3.x.y (main development branch)`).
+    1. Get the PR approved and merged.
+1. For each new version under development:
+    1. Go to the [GitHub
+       milestones](https://github.com/ubccr/xdmod-data/milestones) and add a
+       milestone for the new version under development.
+    1. Create a release prep draft PR for the new version under development:
+        1. In `CHANGELOG.md`:
+            1. Add a heading for the new version under development with a date of
+               `XXXX-XX-XX`.
+            1. If you already know what will be done in the new version under
+               development, write a summary of it.
+            1. Add the expected compatibility with Open XDMoD versions.
+        1. In `README.md`, add the new version under development to the Open XDMoD
+           compatibility matrix.
+        1. In `xdmod_data/__version__.py`, change the version number to the new
+           version under development.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: xdmod_data.__version__
 author = Aaron Weeden, Joseph P. White, Rodney Garnett
 maintainer = Aaron Weeden, Joseph P. White
 description = Python package for Open XDMoD data access
-long_description = See the [README](https://github.com/ubccr/xdmod-data?tab=readme-ov-file#xdmod-data) for instructions on use.
+long_description = See the [README](https://github.com/ubccr/xdmod-data/tree/v2.x.y?tab=readme-ov-file#xdmod-data) for instructions on use.
 long_description_content_type = text/markdown
 license_files = LICENSE
 project_urls =

--- a/xdmod_data/__version__.py
+++ b/xdmod_data/__version__.py
@@ -1,2 +1,2 @@
 __title__ = 'xdmod-data'
-__version__ = '2.0.0.dev11'
+__version__ = '2.0.0.dev12'


### PR DESCRIPTION
Port of https://github.com/ubccr/xdmod-data/pull/70 for the `main` branch.