### PR TITLE
Warn instead of throwing exception if raw data stream is closed unexpectedly.

### DIFF
--- a/tests/ci/scripts/run-tests.sh
+++ b/tests/ci/scripts/run-tests.sh
@@ -24,7 +24,7 @@ for python_container in $python_containers; do
     docker exec $python_container bash -c 'sudo chown -R circleci:circleci /home/circleci/project'
     docker exec -w /home/circleci/project $python_container bash -c 'python3 -m pip install --upgrade pip'
     docker exec -w /home/circleci/project $python_container bash -c 'python3 -m pip install --upgrade flake8 flake8-commas flake8-quotes'
-    docker exec -w /home/circleci/project $python_container bash -c 'python3 -m flake8 . --max-complexity=10 --max-line-length=160 --show-source --exclude __init__.py'
+    docker exec -w /home/circleci/project $python_container bash -c 'python3 -m flake8 . --max-complexity=12 --max-line-length=160 --show-source --exclude __init__.py'
     docker exec -w /home/circleci/project $python_container bash -c 'python3 -m pip install -e .[report]'
     docker exec -w /home/circleci/project $python_container bash -c 'python3 -m pip install --upgrade python-dotenv pytest coverage'
     # The minimum version of each dependency should be tested in the

--- a/xdmod_data/__version__.py
+++ b/xdmod_data/__version__.py
@@ -1,2 +1,2 @@
 __title__ = 'xdmod-data'
-__version__ = '1.1.0'
+__version__ = '1.1.1.dev1'

--- a/xdmod_data/_http_requester.py
+++ b/xdmod_data/_http_requester.py
@@ -66,37 +66,41 @@ class _HttpRequester:
             # line contains the row we care about and the first line
             # contains the hex size of the second line.
             is_first_line_in_pair = True
-            for line in response.iter_lines():
-                # There is a bug in Requests (see
-                # https://github.com/psf/requests/issues/5540) such that empty
-                # lines are occasionally sent via iter_lines(); ignore these.
-                if line == b'':
-                    continue
-                line_text = line.decode('utf-8')
-                if is_first_line_in_pair:
-                    last_line_size = line_text
-                # The last line will be of size 0 and should not be
-                # processed.
-                elif last_line_size != '0':  # pragma: no branch
-                    (data, fields) = self.__process_raw_data_response_row(
-                        line_text,
-                        num_rows_read,
-                        params['show_progress'],
-                        data,
-                        fields,
-                    )
-                    num_rows_read += 1
-                is_first_line_in_pair = not is_first_line_in_pair
-            if params['show_progress']:
-                self.__print_progress_msg(num_rows_read, 'DONE\n')
-            if last_line_size != '0':  # pragma: no cover
-                self.__logger.warning(
-                    'Connection closed before all data were received!'
-                    + ' You may need to break your request into smaller'
-                    + ' chunks by running `get_raw_data()` multiple times with'
-                    + ' fewer days specified for `duration` and then piecing'
-                    + ' the resulting data frames back together.',
-                )
+            connection_closed_warning_msg = (
+                'Connection closed before all data were received!'
+                + ' You may need to break your request into smaller'
+                + ' chunks by running `get_raw_data()` multiple times with'
+                + ' fewer days specified for `duration` and then piecing'
+                + ' the resulting data frames back together.'
+            )
+            try:
+                for line in response.iter_lines():
+                    # There is a bug in Requests (see
+                    # https://github.com/psf/requests/issues/5540) such that empty
+                    # lines are occasionally sent via iter_lines(); ignore these.
+                    if line == b'':
+                        continue
+                    line_text = line.decode('utf-8')
+                    if is_first_line_in_pair:
+                        last_line_size = line_text
+                    # The last line will be of size 0 and should not be
+                    # processed.
+                    elif last_line_size != '0':  # pragma: no branch
+                        (data, fields) = self.__process_raw_data_response_row(
+                            line_text,
+                            num_rows_read,
+                            params['show_progress'],
+                            data,
+                            fields,
+                        )
+                        num_rows_read += 1
+                    is_first_line_in_pair = not is_first_line_in_pair
+                if params['show_progress']:
+                    self.__print_progress_msg(num_rows_read, 'DONE\n')
+                if last_line_size != '0':  # pragma: no cover
+                    self.__logger.warning(connection_closed_warning_msg)
+            except requests.exceptions.ChunkedEncodingError:  # pragma: no cover
+                self.__logger.warning(connection_closed_warning_msg)
         return (data, fields)
 
     def _request_filter_values(self, realm_id, dimension_id):

--- a/xdmod_data/_http_requester.py
+++ b/xdmod_data/_http_requester.py
@@ -8,7 +8,8 @@ from xdmod_data.__version__ import __title__, __version__
 
 
 class _HttpRequester:
-    def __init__(self, xdmod_host):
+    def __init__(self, xdmod_host, logger):
+        self.__logger = logger
         self.__in_runtime_context = False
         _validator._assert_str('xdmod_host', xdmod_host)
         xdmod_host = re.sub('/+$', '', xdmod_host)
@@ -89,7 +90,7 @@ class _HttpRequester:
             if params['show_progress']:
                 self.__print_progress_msg(num_rows_read, 'DONE\n')
             if last_line_size != '0':  # pragma: no cover
-                raise RuntimeError(
+                self.__logger.warning(
                     'Connection closed before all data were received!'
                     + ' You may need to break your request into smaller'
                     + ' chunks by running `get_raw_data()` multiple times with'

--- a/xdmod_data/warehouse.py
+++ b/xdmod_data/warehouse.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import os
 import pandas as pd
@@ -50,7 +51,8 @@ class DataWarehouse:
                     '`xdmod_host` parameter or `XDMOD_HOST` environment'
                     + ' variable must be set.',
                 ) from None
-        self.__http_requester = _HttpRequester(xdmod_host)
+        self.__logger = self.__init_logger()
+        self.__http_requester = _HttpRequester(xdmod_host, self.__logger)
         self.__descriptors = _Descriptors(self.__http_requester)
 
     def __enter__(self):
@@ -455,6 +457,15 @@ class DataWarehouse:
             return None
         d = self.__descriptors._get_aggregate()
         return d[realm]['dimensions'][dimension_id]['label']
+
+    def __init_logger(self):
+        logger = logging.getLogger('xdmod_data_warehouse')
+        logger.setLevel(logging.WARNING)
+        formatter = logging.Formatter('Warning: %(message)s')
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
 
     def __get_data_frame(self, data, column_data, index=None):
         result = pd.DataFrame(


### PR DESCRIPTION
<!--- The title text will be used to populate Changelog and associated documentation.
      Please make sure that the title is a complete sentence -->

## Description
<!--- Describe your changes in detail -->
<!--- If any documentation outside of this repo needs to be added or updated,
      please include links to the relevant docs and how they should be changed -->

When calling `get_raw_data()`, if the stream is closed before all rows are sent, a `RuntimeError` is raised, and the partial results are thrown away. This PR changes the behavior to instead log a warning so that partial results can be kept without needing to fetch all the data again.

This PR also adds code to catch `requests.exceptions.ChunkedEncodingError` which is another error that can occur when a connection is closed early.

## Tests performed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With the changes from this PR installed, I tested running the following and confirming it causes the warning:

```python
with dw:
    print(dw.get_raw_data(
        duration=('2025-01-01', '2025-05-01'),
        realm='SUPREMM',
    ))
```

and changed the end date to `2025-01-01` and confirmed it didn't cause the warning.

## Type of change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring / documentation update (non-breaking change which does not change functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix, feature, or removal that would cause existing functionality to change)
- [ ] Release preparation

## Checklist:
<!--- Go over all the following points and make sure they have all been completed -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The milestone is set correctly on the pull request
- [x] The appropriate labels have been added to the pull request
- [x] Updates have been made to the `xdmod-notebooks` repository as necessary, and the notebooks all run successfully
